### PR TITLE
Sneak instead of steal

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ app.post("/build-finished", function(req, res) {
     if (build.state === "passed") {
       postToChannel("cancel deploy-prod");
     } else {
-      postToChannel("steal deploy-prod");
+      postToChannel("sneak deploy-prod");
       postToChannel("infrastructure-specs are broken! Please fix before deploying to prod... :angry:");
     }
   }


### PR DESCRIPTION
Sneak will add the infra-nagger to the front of the queue, without altering the exiting queue order.
